### PR TITLE
add top-level headers config applied to all requests

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -15,3 +15,6 @@ loadbeat:
   # How long to wait for a response for each request
   #request_timeout: 5s
 
+  # Headers added to every request
+  #headers:
+  #  - "set-cookie: ABC=; expires=Mon, 01-Jan-1990 00:00:00 GMT; path=/; domain=.example.com"

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Keepalives     bool          `config:"keepalives.enabled"`
 	Redirects      bool          `config:"redirects.enabled"`
 	RequestTimeout time.Duration `config:"request_timeout"`
+	Headers        []string      `config:"headers"`
 
 	// Work Config
 	BaseUrls    []string       `config:"base_urls"`
@@ -37,6 +38,7 @@ var DefaultConfig = Config{
 	Keepalives:     true,
 	Redirects:      true,
 	RequestTimeout: 5 * time.Second,
+	Headers:        []string{},
 
 	BaseUrls:    []string{"http://apm-server:8200/"},
 	MaxRequests: math.MaxInt32,

--- a/loadbeat.reference.yml
+++ b/loadbeat.reference.yml
@@ -15,6 +15,9 @@ loadbeat:
   # How long to wait for a response for each request
   #request_timeout: 5s
 
+  # Headers added to every request
+  #headers:
+  #  - "set-cookie: ABC=; expires=Mon, 01-Jan-1990 00:00:00 GMT; path=/; domain=.example.com"
 
 #================================ General ======================================
 

--- a/loadbeat.yml
+++ b/loadbeat.yml
@@ -15,6 +15,9 @@ loadbeat:
   # How long to wait for a response for each request
   #request_timeout: 5s
 
+  # Headers added to every request
+  #headers:
+  #  - "set-cookie: ABC=; expires=Mon, 01-Jan-1990 00:00:00 GMT; path=/; domain=.example.com"
 
 #================================ General =====================================
 


### PR DESCRIPTION
previously only target-specific headers were supported.